### PR TITLE
LSDS-1385 Add time to the requires for espa-processing

### DIFF
--- a/espa-processing/SPECS/espa-processing.spec
+++ b/espa-processing/SPECS/espa-processing.spec
@@ -30,6 +30,7 @@ Requires:       python-gdal
 Requires:	python-watchtower
 Requires:	awscli
 Requires:	rsync
+Requires:	time
 
 %description
 %summary


### PR DESCRIPTION
To get fine grain time data we need the standalone
time package.